### PR TITLE
Prop "overrideStyle" missing on Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Roundy provides the following API:
 | color | string: Active slider color | 'purple' |
 | bgColor | string: Slider arc color | '#ccc' |
 | strokeWidth | number: Slider arc width | 15 |
+| thumbSize | number: Size (diameter) of thumb | 20 |
 | sliced | boolean: Provide slices based on step value | true |
 | onChange | function: immediate callback function (value, props) | null |
 | onAfterChange | function: callback function after release (value, props) | null |

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,8 @@ class Roundy extends Component {
       style,
       arcSize,
       rotationOffset,
-      allowClick
+      allowClick,
+      overrideStyle
     } = this.props
     const { angle } = this.state
     const segments =
@@ -262,6 +263,7 @@ class Roundy extends Component {
         onTouchCancel={this.up}
         style={style}
         allowClick={allowClick}
+        overrideStyle={overrideStyle}
       >
         {render ? (
           // use render props


### PR DESCRIPTION
In `index.js`, the prop `overrideStyle` is not present on the Wrapper component. If I add the prop here, it works:

```css
overrideStyle={`
    svg path { opacity: 1; } /* correcting fixed value of 0.7 */
    .sliderHandle:after {   /* Just testing */
        background: pink;
    }
`}
```

Also, I added `thumbSize` to the documentation. It was missing, but is quite helpful.